### PR TITLE
BUGFIX: Parsed to a wrong number when running on an OS with English set as language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 src/web/root/.aspnet/DataProtection-Keys
 ops/*
 src/data/logs
+
+**/.vs/**
+**/bin/**
+**/obj/**

--- a/src/Services/HtmlServices/ValueParser.cs
+++ b/src/Services/HtmlServices/ValueParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 
 namespace StiebelEltronDashboard.Services.HtmlServices
 {
@@ -12,14 +13,17 @@ namespace StiebelEltronDashboard.Services.HtmlServices
             {
                 rawValue = rawValue.Substring(1,rawValue.Length-1);
             }
-            var decimalValue = rawValue.Trim().Replace(',', '.');
+
+            var sourceSeparator = ',';
+            var targetSeparator = Convert.ToChar(Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+            var decimalValue = rawValue.Trim().Replace(sourceSeparator, targetSeparator);
             var number = new StringBuilder();
             var unit = new StringBuilder();
                       
             foreach (var d in decimalValue)
             {
                 var isNumeric = int.TryParse(d.ToString(), out _);
-                var isDot = d == '.';
+                var isDot = d == targetSeparator;
                 if (isNumeric || isDot)
                 {
                     number.Append(d);


### PR DESCRIPTION
Fixed by using `NumberDecimalSeparator` of the `CurrentCulture`.

You should add to the "Known limitations" in the README.md that currently on parsing the German page of the ISG is supported.
Other languages can be maybe supported in the future. For me currently there are the following:
DEUTSCH
ENGLISH
FRANCAIS
NEDERLANDS
ITALIANO
SVENSKA
POLSKI
CESTINA
MAGYAR
ESPANOL
SUOMI
DANSK